### PR TITLE
Update to allow text to overlay full screen album art

### DIFF
--- a/display_controller.py
+++ b/display_controller.py
@@ -16,7 +16,7 @@ class SonosDisplaySetupError(Exception):
 class DisplayController:  # pylint: disable=too-many-instance-attributes
     """Controller to handle the display hardware and GUI interface."""
 
-    def __init__(self, loop, show_details, show_artist_and_album, show_details_timeout):
+    def __init__(self, loop, show_details, show_artist_and_album, show_details_timeout, overlay_text):
         """Initialize the display controller."""
         
         self.SCREEN_W = 720
@@ -28,6 +28,7 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         self.show_details = show_details
         self.show_artist_and_album = show_artist_and_album
         self.show_details_timeout = show_details_timeout
+        self.overlay_text = overlay_text
 
         self.album_image = None
         self.thumb_image = None
@@ -206,11 +207,15 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         
         # Store the images as attributes to preserve scope for Tk
         self.album_image = resize_image(image, self.SCREEN_W)
-        self.thumb_image = resize_image(image, self.THUMB_W)
-
-        self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
+        if self.overlay_text:
+            self.thumb_image = resize_image(image, self.SCREEN_W)
+            self.label_albumart_detail.place(relx=0.5, rely=0.5, anchor=tk.CENTER)
+        else:
+            self.thumb_image = resize_image(image, self.THUMB_W)
+            self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
+        
         self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
-        if detail_text == "":
+        if detail_text == "" or not self.show_artist_and_album:
             self.label_detail.place(relx=0.5, y=self.SCREEN_H + 10, anchor=tk.S)
         else:
             self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -154,8 +154,9 @@ async def main(loop):
     setup_logging()
     log_git_hash()
     show_details_timeout = getattr(sonos_settings, "show_details_timeout", None)
+    
     try:
-        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout)
+        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout, sonos_settings.overlay_text)
     except SonosDisplaySetupError:
         loop.stop()
         return

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -154,9 +154,10 @@ async def main(loop):
     setup_logging()
     log_git_hash()
     show_details_timeout = getattr(sonos_settings, "show_details_timeout", None)
+    overlay_text = getattr(sonos_settings, "overlay_text", None)
     
     try:
-        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout, sonos_settings.overlay_text)
+        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout, overlay_text)
     except SonosDisplaySetupError:
         loop.stop()
         return

--- a/sonos_settings.py.example
+++ b/sonos_settings.py.example
@@ -36,6 +36,9 @@ show_artist_and_album = True
 # Display artist and album with track name with a new look. Ignored if 'show_details' is False.
 artist_and_album_newlook = True
 
+# Display Track, Album and Artist Information over fullscreen Album Art
+overlay_text = True
+
 # Turn off display (and backlight) when Sonos is playing from a TV source
 sleep_on_tv = False
 


### PR DESCRIPTION
Adding the ability to overlay track title, Album, and Artist details over a fullscreen album art image. Requires a new parameter (overlay_text) to be set to True in sonos_settings.py, if set to False text is displayed below a thumbnail of the album art